### PR TITLE
Add unit tests and refactor scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # playground
+
+To run the automated test suite execute:
+
+```bash
+pytest
+```
+
+This will run all unit tests located in the `tests/` directory.

--- a/scripts/logistic_regression.py
+++ b/scripts/logistic_regression.py
@@ -1,15 +1,10 @@
 # load data for logistic regression
-import pandas as pd
 import os
-import numpy as np
 import random
+
+import numpy as np
+import pandas as pd
 from matplotlib import pyplot as plt
-
-csv_file_path = os.path.dirname(os.path.abspath(__file__)) + "/breast_cancer.csv"
-df = pd.read_csv(csv_file_path)
-
-# try to replace the values (2=benign) and (4=malignant) by 0 and 1
-df["Class"] = df["Class"].replace({2: 0, 4: 1})
 
 # now start with the logistic regression ;)
 
@@ -54,41 +49,47 @@ class LogisticRegression:
         return corrects / len(y)
 
 
-# initialize
-X = df.drop(columns="Class").to_numpy()  # get the whole dat
-
-# now normalize the data-> tomorrow
-y = df["Class"].to_numpy()
-# split into training and test
-indices = list(range(len(y)))
-random.shuffle(indices)
-split_idx = int(len(y) * 0.6)
-X_train, y_train = X[indices[:split_idx]], y[indices[:split_idx]]
-X_test, y_test = X[indices[split_idx:]], y[indices[split_idx:]]
+def load_data():
+    """Load and return the breast cancer dataset used in the examples."""
+    csv_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "breast_cancer.csv")
+    df = pd.read_csv(csv_file_path)
+    df["Class"] = df["Class"].replace({2: 0, 4: 1})
+    X = df.drop(columns="Class").to_numpy()
+    y = df["Class"].to_numpy()
+    return X, y
 
 
-logistic_regressor = LogisticRegression(X)
-pred = logistic_regressor.probability(X)
-loss = logistic_regressor.loss(pred, y)
-print(f"loss is {logistic_regressor.loss(pred,y)}")
-# testplot
-# print(logitistic_regressor.loss(pred, y))
+def main():
+    X, y = load_data()
 
-# # now train the regression
-train_losses = []
-test_accuracies = []
-for i in range(100000):
-    logistic_regressor.train(X_train, y_train)
-    if i % 1000 == 0:
-        train_loss = logistic_regressor.loss(
-            logistic_regressor.probability(X_train), y_train
-        )
-        test_accuracy = logistic_regressor.accuracy(X_test, y_test)
-        print(f"Training step {i}")
-        print(f"training loss is {train_loss}")
-        print(f"test accuracy is {test_accuracy}")
-        train_losses.append(train_loss)
-        test_accuracies.append(test_accuracy)
-plt.plot(train_losses)
-plt.plot(test_accuracies)
-plt.show()
+    indices = list(range(len(y)))
+    random.shuffle(indices)
+    split_idx = int(len(y) * 0.6)
+    X_train, y_train = X[indices[:split_idx]], y[indices[:split_idx]]
+    X_test, y_test = X[indices[split_idx:]], y[indices[split_idx:]]
+
+    logistic_regressor = LogisticRegression(X)
+    pred = logistic_regressor.probability(X)
+    print(f"loss is {logistic_regressor.loss(pred,y)}")
+
+    train_losses = []
+    test_accuracies = []
+    for i in range(100000):
+        logistic_regressor.train(X_train, y_train)
+        if i % 1000 == 0:
+            train_loss = logistic_regressor.loss(
+                logistic_regressor.probability(X_train), y_train
+            )
+            test_accuracy = logistic_regressor.accuracy(X_test, y_test)
+            print(f"Training step {i}")
+            print(f"training loss is {train_loss}")
+            print(f"test accuracy is {test_accuracy}")
+            train_losses.append(train_loss)
+            test_accuracies.append(test_accuracy)
+    plt.plot(train_losses)
+    plt.plot(test_accuracies)
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_array_acrobatics.py
+++ b/tests/test_array_acrobatics.py
@@ -1,0 +1,12 @@
+import pytest
+
+np = pytest.importorskip('numpy')
+
+from scripts.array_acrobatics import convolution2D
+
+
+def test_convolution2d_small():
+    image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    kernel = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
+    result = convolution2D(image, kernel)
+    assert np.array_equal(result, np.array([[5]]))

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,65 @@
+from importlib import import_module
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_worker_callback_calls():
+    mod = import_module('scripts.callback')
+
+    class Dummy(mod.callback):
+        def __init__(self):
+            self.begin_called = 0
+            self.iter_called = 0
+
+        def on_begin(self):
+            self.begin_called += 1
+
+        def on_iteration(self):
+            self.iter_called += 1
+
+    dummy = Dummy()
+    mod.worker([dummy])
+    assert dummy.begin_called == 1
+    assert dummy.iter_called == 50
+
+
+def test_worker_playground_callback_calls():
+    mod = import_module('scripts.callback_playground')
+
+    class Dummy(mod.callback):
+        def __init__(self):
+            self.begin_called = 0
+            self.iter_called = 0
+
+        def on_begin(self):
+            self.begin_called += 1
+
+        def on_iteration(self):
+            self.iter_called += 1
+
+    dummy = Dummy()
+    mod.worker([dummy])
+    assert dummy.begin_called == 1
+    assert dummy.iter_called == 50
+
+
+def test_worker_callback2_calls():
+    mod = import_module('scripts.callback2')
+
+    class Dummy(mod.Callback):
+        def __init__(self):
+            self.begin_called = 0
+            self.iter_called = 0
+
+        def on_begin(self):
+            self.begin_called += 1
+
+        def on_iteration(self):
+            self.iter_called += 1
+
+    dummy = Dummy()
+    mod.worker([dummy])
+    assert dummy.begin_called == 1
+    assert dummy.iter_called == 50

--- a/tests/test_derivative.py
+++ b/tests/test_derivative.py
@@ -1,0 +1,20 @@
+import importlib
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+np = pytest.importorskip('numpy')
+plt = pytest.importorskip('matplotlib.pyplot')
+
+
+def test_shift_and_derivative(monkeypatch):
+    monkeypatch.setattr(plt, 'show', lambda: None)
+    module = importlib.import_module('scripts.derivative')
+    arr = np.array([1, 2, 3])
+    shifted = module.shift(arr)
+    assert np.array_equal(shifted, np.array([3, 1, 2]))
+    deriv = module.derivative(arr, 1)
+    expected = shifted - arr
+    assert np.array_equal(deriv, expected)

--- a/tests/test_fizz_buzz.py
+++ b/tests/test_fizz_buzz.py
@@ -1,0 +1,27 @@
+import sys
+import subprocess
+from pathlib import Path
+
+
+def test_fizz_buzz_first_15():
+    script = Path(__file__).resolve().parents[1] / 'scripts' / 'fizz_buzz.py'
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    lines = result.stdout.strip().splitlines()[:15]
+    expected = [
+        '1',
+        '2',
+        'Fizz!',
+        '4',
+        'Buzz!',
+        'Fizz!',
+        '7',
+        '8',
+        'Fizz!',
+        'Buzz!',
+        '11',
+        'Fizz!',
+        '13',
+        '14',
+        'FizzBuzz!',
+    ]
+    assert lines == expected

--- a/tests/test_generator_example.py
+++ b/tests/test_generator_example.py
@@ -1,0 +1,11 @@
+from importlib import import_module
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_flo_generator_yields_in_order():
+    mod = import_module('scripts.generator_example')
+    gen = mod.flo_generator([1, 2, 3])
+    assert list(gen) == [1, 2, 3]

--- a/tests/test_logistic_regression.py
+++ b/tests/test_logistic_regression.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+np = pytest.importorskip('numpy')
+
+from scripts.logistic_regression import LogisticRegression
+
+
+def test_sigmoid():
+    lr = LogisticRegression(np.zeros((1, 1)))
+    assert pytest.approx(lr.sigmoid(0)) == 0.5
+
+
+def test_probability_and_loss_and_update():
+    lr = LogisticRegression(np.zeros((2, 1)))
+    lr.a = np.array([1.0])
+    lr.b = 0.0
+    X = np.array([[0.0], [1.0]])
+    preds = lr.probability(X)
+    expected = lr.sigmoid(np.array([0.0, 1.0]))
+    assert np.allclose(preds, expected)
+
+    y = np.array([0, 1])
+    loss = lr.loss(preds, y)
+    expected_loss = -np.mean(y * np.log(preds) + (1 - y) * np.log(1 - preds))
+    assert np.isclose(loss, expected_loss)
+
+    lr.a_grad = np.array([0.1])
+    lr.b_grad = 0.2
+    a_prev, b_prev = lr.a.copy(), lr.b
+    lr.update(0.5)
+    assert np.allclose(lr.a, a_prev - 0.5 * 0.1)
+    assert np.isclose(lr.b, b_prev - 0.5 * 0.2)

--- a/tests/test_logistic_regression_pytorch.py
+++ b/tests/test_logistic_regression_pytorch.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+torch = pytest.importorskip('torch')
+
+lr_mod = importlib.import_module('scripts.logistic_regression_pytorch')
+
+
+def test_sigmoid():
+    model = lr_mod.LogisticRegression(torch.zeros((1, 1)))
+    assert torch.isclose(model.sigmoid(torch.tensor(0.0)), torch.tensor(0.5))
+
+
+def test_probability_loss_update():
+    model = lr_mod.LogisticRegression(torch.zeros((2, 1)))
+    model.a = torch.tensor([1.0], dtype=lr_mod.dtype, device=lr_mod.device, requires_grad=True)
+    model.b = torch.tensor(0.0, dtype=lr_mod.dtype, device=lr_mod.device, requires_grad=True)
+    X = torch.tensor([[0.0], [1.0]], dtype=lr_mod.dtype, device=lr_mod.device)
+    preds = model.probability(X)
+    expected = model.sigmoid(torch.tensor([0.0, 1.0], dtype=lr_mod.dtype, device=lr_mod.device))
+    assert torch.allclose(preds, expected)
+
+    y = torch.tensor([0.0, 1.0], dtype=lr_mod.dtype, device=lr_mod.device)
+    loss_val = model.loss(preds, y)
+    expected_loss = -torch.mean(y * torch.log(preds) + (1 - y) * torch.log(1 - preds))
+    assert torch.allclose(loss_val, expected_loss)
+
+    model.a.grad = torch.tensor([0.1], dtype=lr_mod.dtype, device=lr_mod.device)
+    model.b.grad = torch.tensor(0.2, dtype=lr_mod.dtype, device=lr_mod.device)
+    a_before = model.a.clone()
+    b_before = model.b.clone()
+    model.update(0.5)
+    assert torch.allclose(model.a, a_before - 0.5 * 0.1)
+    assert torch.allclose(model.b, b_before - 0.5 * 0.2)

--- a/tests/test_traverse_order_search.py
+++ b/tests/test_traverse_order_search.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.traverse_order_search import TreeNode, level_order_search
+
+
+def build_tree():
+    root = TreeNode(1)
+    root.left = TreeNode(2)
+    root.right = TreeNode(3)
+    root.left.left = TreeNode(4)
+    root.left.right = TreeNode(5)
+    return root
+
+
+def test_level_order_found():
+    root = build_tree()
+    assert level_order_search(root, 4) is True
+
+
+def test_level_order_not_found():
+    root = build_tree()
+    assert level_order_search(root, 6) is False


### PR DESCRIPTION
## Summary
- add `tests/` suite covering various scripts
- refactor logistic regression examples to use `main()`
- make `scripts` a package and update README with test instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5977af1483279a0cd1a22df8445c